### PR TITLE
Update vso.py

### DIFF
--- a/sunpy/net/vso/vso.py
+++ b/sunpy/net/vso/vso.py
@@ -419,6 +419,14 @@ class VSOClient(BaseClient):
 
     def make_getdatarequest(self, response, methods=None, info=None):
         """ Make datarequest with methods from response. """
+        
+        #    Pass back the Apache session ID to the VSO if it exists in the response
+
+        for item in response:
+           for k in item.keys():
+              if k == 'Info Required':
+                 info['required'] = item['Info Required']
+                
         if methods is None:
             methods = self.method_order + ['URL']
 


### PR DESCRIPTION
Return to the VSO the key "Info Required" in the query response so that subsequent Fido fetches will get the correct data from the VSO. NOTE: Only REST and/or TAP Data Providers return the key "Info Required" which contains the Apache session ID which the VSO backend uses to distinguish different REST/TAP queries from one another. Existing SOAP Data Providers do NOT return "Info Required".